### PR TITLE
hdf5.go::Attributes() incorrectly returned the global attributes for subgroups

### DIFF
--- a/netcdf/hdf5/hdf5.go
+++ b/netcdf/hdf5/hdf5.go
@@ -3074,9 +3074,9 @@ loop:
 // Attributes returns the global attributes for this group.
 func (h5 *HDF5) Attributes() api.AttributeMap {
 	// entry point, panic can bubble up
-	assert(h5.rootObject != nil, "nil root object")
-	h5.sortAttrList(h5.rootObject)
-	return h5.getAttributes(h5.rootObject.attrlist)
+	assert(h5.groupObject != nil, "nil root object")
+	h5.sortAttrList(h5.groupObject)
+	return h5.getAttributes(h5.groupObject.attrlist)
 }
 
 func (h5 *HDF5) hasAddr(addr uint64) bool {

--- a/netcdf/hdf5/hdf5_test.go
+++ b/netcdf/hdf5/hdf5_test.go
@@ -811,6 +811,14 @@ func TestGlobalAttrs(t *testing.T) {
 			t.Error("type not found for", a)
 		}
 	}
+
+	// test global attributes of subgroups...
+	snc, _ := nc.GetGroup("subgroup")
+	got = snc.Attributes()
+	_, has := got.Get("groupattr")
+	if !has {
+		t.Error("Could not find subgroup attribute")
+	}
 }
 
 func checkAllAttrs(t *testing.T, name string, got api.AttributeMap, exp api.AttributeMap) {

--- a/netcdf/hdf5/testdata/testattrs.cdl
+++ b/netcdf/hdf5/testdata/testattrs.cdl
@@ -44,4 +44,8 @@ variables:
   int64 :i64 = 9;
 
   uint64 :ui64 = 10;
+data:
+  group: subgroup {
+    :groupattr = "foo";
+  }
 }


### PR DESCRIPTION
Please accept this simple fix and unit test for returning subgroup global attributes.

I am interested in contributing further to this library -- please reach out to me about possible collaboration:

  Rick Brownrigg
  brownrig@ucar.edu

Thanks
